### PR TITLE
express-validator: fix and new methods

### DIFF
--- a/express-validator/express-validator.d.ts
+++ b/express-validator/express-validator.d.ts
@@ -65,7 +65,7 @@ declare module ExpressValidator {
 		/**
 		 * Accepts http, https, ftp
 		 */
-		isUrl(): Validator;
+		isURL(): Validator;
 		/**
 		 * Combines isIPv4 and isIPv6
 		 */
@@ -111,6 +111,7 @@ declare module ExpressValidator {
 		/**
 		 * max is optional
 		 */
+		isLength(min:number, max?:number): Validator;
 		len(min:number, max?:number): Validator;
 		/**
 		 * Version can be 3, 4 or 5 or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
@@ -154,6 +155,14 @@ declare module ExpressValidator {
 		 * Check an input only when the input exists
 		 */
 		optional(): Validator;
+		/**
+		 * Check string to be a valid date according to ISO 8601
+		 */
+		isISO8601(): Validator;
+		/**
+		 * Check string to be a valid mongoID
+		 */
+		isMongoId(): Validator;
 	}
 
 	interface Sanitizer {


### PR DESCRIPTION
Added new methods (isMongoId(), isISO8601(), isLength()) now available in validator.js
Replaced isUrl() with isURL()
